### PR TITLE
Fix tasks reporting

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -86,17 +86,15 @@
             },
             "command": "./checks/run_pyspelling.py",
             "problemMatcher": {
-                "severity": "info",
-                "pattern": [{
+                "pattern": {
                     "regexp": "^::(notice|warning|error) file=(.*?),line=([0-9]*),col=([0-9]*),endColumn=([0-9]*),title=(.*?)::(.*)$",
                     "severity": 1,
                     "file": 2,
                     "line": 3,
                     "column": 4,
-                    "endLine": 5,
+                    "endColumn": 5,
                     "message": 7,
-                    "loop": true
-                    }],
+                },
                 "owner": "spelling",
                 "fileLocation": "autoDetect",
             },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,7 +1,5 @@
 {
-
     // Multiple patterns currently don't work, so make sure each task outputs only ONE type of message.
-
     "version":"2.0.0",
     "tasks": [
         {
@@ -20,24 +18,19 @@
             },
             "command": "./checks/run_meta_check.py",
             "problemMatcher": {
-                "severity": "info",
-                "pattern": [
-                    {
-                        "regexp": "^::(notice|warning|error) file=(.*?),title=(.*?),col=([0-9]*),endColumn=([0-9]*),line=([0-9]*)::(.*)$",
-                        "severity": 1,
-                        "file": 2,
-                        "code": 3,
-                        "column": 4,
-                        "endColumn": 5,
-                        "line": 6,
-                        "message": 7,
-                        "loop": true
-                    },
-                ],
+                "pattern": {
+                    "regexp": "^::(notice|warning|error) file=(.*?),title=(.*?),col=([0-9]*),endColumn=([0-9]*),line=([0-9]*)::(.*)$",
+                    "severity": 1,
+                    "file": 2,
+                    "code": 3,
+                    "column": 4,
+                    "endColumn": 5,
+                    "line": 6,
+                    "message": 7,
+                },
                 "owner": "meta-check",
                 "fileLocation": "autoDetect",
             },
-            
         },
         {
             "label": "proselint-checks",
@@ -55,7 +48,6 @@
             },
             "command": "./checks/run_proselint.py",
             "problemMatcher": {
-                "severity": "info",
                 "pattern": {
                     "regexp": "^::(notice|warning|error) file=(.*?),line=([0-9]*),col=([0-9]*),endColumn=([0-9]*),title=(.*?)::(.*)$",
                     "severity": 1,
@@ -64,7 +56,6 @@
                     "column": 4,
                     "endLine": 5,
                     "message": 7,
-                    "loop": true
                 },
                 "owner": "proselint",
                 "fileLocation": "autoDetect",
@@ -102,7 +93,6 @@
         {
             "label": "build",
             "type": "shell",
-
             "isBackground": true,
             "presentation": {
                 "echo": true,

--- a/checks/run_meta_check.py
+++ b/checks/run_meta_check.py
@@ -10,6 +10,7 @@ import re
 import sys
 import yaml
 import os
+import time
 from pathlib import Path
 
 # Ignore files if they match this regex
@@ -259,3 +260,7 @@ WALKCHECKS = [click_here]
 
 if __name__ == "__main__":
     main()
+
+    # FIXME terrible hack to make VSCode in codespace capture the error messages
+    # see https://github.com/microsoft/vscode/issues/92868 as a tentative explanation
+    time.sleep(5)

--- a/checks/run_proselint.py
+++ b/checks/run_proselint.py
@@ -10,19 +10,20 @@ from proselint import config, tools
 
 if __name__ == "__main__":
 
-    ret_code = 0
-
     files = sys.argv[1:]
 
     # Load defaults from config.
-    config_custom = tools.load_options(config_file_path=".proselint.json", conf_default=config.default)
+    config_custom = tools.load_options(
+        config_file_path=".proselint.json", conf_default=config.default
+    )
 
     for file in files:
         print(f"Running proselint on {file}")
         with open(file, "r", encoding="utf8") as f:
             for notice in proselint.tools.lint(f.read(), config=config_custom):
-                ret_code += 1
-                print(f"::{notice[7]} file={file},line={notice[2]+1},col={notice[3]+2},endColumn={notice[2]+notice[6]+1},title={notice[0]}::'{notice[1]}'", flush=True)
-                sys.stdout.flush()
-    sys.exit(0)
-    # sys.exit(ret_code)
+                print(
+                    f"::{notice[7]} file={file},line={notice[2]+1},"
+                    f"col={notice[3]+2},endColumn={notice[2]+notice[6]+1},"
+                    f"title={notice[0]}::'{notice[1]}'",
+                    flush=True,
+                )

--- a/checks/run_proselint.py
+++ b/checks/run_proselint.py
@@ -5,6 +5,8 @@ Modify proselint outputs into a format recognised by github actions.
 """
 
 import sys
+from pathlib import Path
+
 import proselint
 from proselint import config, tools
 
@@ -19,11 +21,11 @@ if __name__ == "__main__":
 
     for file in files:
         print(f"Running proselint on {file}")
-        with open(file, "r", encoding="utf8") as f:
-            for notice in proselint.tools.lint(f.read(), config=config_custom):
-                print(
-                    f"::{notice[7]} file={file},line={notice[2]+1},"
-                    f"col={notice[3]+2},endColumn={notice[2]+notice[6]+1},"
-                    f"title={notice[0]}::'{notice[1]}'",
-                    flush=True,
-                )
+        content = Path(file).read_text(encoding="utf8")
+        for notice in proselint.tools.lint(content, config=config_custom):
+            print(
+                f"::{notice[7]} file={file},line={notice[2]+1},"
+                f"col={notice[3]+2},endColumn={notice[2]+notice[6]+1},"
+                f"title={notice[0]}::'{notice[1]}'",
+                flush=True,
+            )

--- a/checks/run_pyspelling.py
+++ b/checks/run_pyspelling.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
-"""
-I should just use base aspell. Pyspelling is trasssssh
-"""
+# FIXME direct use of aspell might be simpler than postprocessing pyspelling
 
 import sys
 import re

--- a/checks/run_pyspelling.py
+++ b/checks/run_pyspelling.py
@@ -10,8 +10,6 @@ from pyspelling import spellcheck
 
 if __name__ == "__main__":
 
-    ret_code = 0
-
     for source in sys.argv[1:]:
         with open(source) as f:
             print(f"Running Pyspelling on {f}")
@@ -39,9 +37,10 @@ if __name__ == "__main__":
                         )
                         for m in matches:
                             print(
-                                f"::warning file={source},line={line_no},col={m.start()+3},endColumn={m.end()},\
-title=spelling::Word '{word}' is mispeled."
+                                f"::warning file={source},line={line_no},"
+                                f"col={m.start()+3},endColumn={m.end()},"
+                                f"title=spelling::Word '{word}' is misspelled.",
+                                flush=True,
                             )
-                            sys.stdout.flush()
 
         sys.exit(0)

--- a/checks/run_pyspelling.py
+++ b/checks/run_pyspelling.py
@@ -3,7 +3,6 @@
 # FIXME direct use of aspell might be simpler than postprocessing pyspelling
 
 import sys
-import re
 from pathlib import Path
 
 from pyspelling import spellcheck

--- a/checks/run_pyspelling.py
+++ b/checks/run_pyspelling.py
@@ -16,19 +16,32 @@ if __name__ == "__main__":
         with open(source) as f:
             print(f"Running Pyspelling on {f}")
             source_md = f.readlines()
-        results = spellcheck(".spellcheck.yml", names=["Markdown"], sources=[source], verbose=0, debug=True)
+
+        results = spellcheck(
+            ".spellcheck.yml",
+            names=["Markdown"],
+            sources=[source],
+            verbose=0,
+            debug=True,
+        )
+
         for r in results:
             if not r.words:
                 continue
+
             for word in r.words:
                 line_no = 0
                 for line in source_md:
                     line_no += 1
                     for word in r.words:
-                        matches = re.finditer(r"[^a-zA-Z`._/[\\-]+(" + word + r")[^a-zA-Z`_/\\-]+", line)
+                        matches = re.finditer(
+                            r"[^a-zA-Z`._/[\\-]+(" + word + r")[^a-zA-Z`_/\\-]+", line
+                        )
                         for m in matches:
-                            print(f"::warning file={source},line={line_no},col={m.start()+3},endColumn={m.end()},\
-title=spelling::Word '{word}' is mispeled.")
+                            print(
+                                f"::warning file={source},line={line_no},col={m.start()+3},endColumn={m.end()},\
+title=spelling::Word '{word}' is mispeled."
+                            )
                             sys.stdout.flush()
 
         sys.exit(0)

--- a/checks/run_pyspelling.py
+++ b/checks/run_pyspelling.py
@@ -3,6 +3,7 @@
 # FIXME direct use of aspell might be simpler than postprocessing pyspelling
 
 import sys
+import time
 from pathlib import Path
 
 from pyspelling import spellcheck
@@ -38,3 +39,7 @@ if __name__ == "__main__":
                     f"title=spelling::Word '{word}' is misspelled.",
                     flush=True,
                 )
+
+    # FIXME terrible hack to make VSCode in codespace capture the error messages
+    # see https://github.com/microsoft/vscode/issues/92868 as a tentative explanation
+    time.sleep(5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ proselint
 linkcheckmd
 symspellpy
 pyspelling
+flashtext
 
 # Add your custom theme if not inside a theme_dir
 # (https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes)


### PR DESCRIPTION
I have fixed the issue with reporting only the first error in VSCode (codespace). It seems to be due to the VSCode parser giving (exiting?) too soon before the checker has actually finished. This is "fixed" by adding a small `time.sleep` at the end of the checkers that had issues (meta checker and spell checker, proselint seemed fine). This hack should be removed once/if the VSCode bug is fixed. See https://github.com/microsoft/vscode/issues/92868 for what, I believe, is the root of the issue.

In addition, this pull request also add some refactoring of the task.json and checker scripts, see commit messages for more details ;).